### PR TITLE
removed default browser behavior to prevent scrolling when zoomed and…

### DIFF
--- a/game.js
+++ b/game.js
@@ -1811,6 +1811,7 @@ function game_make(opts) {
             if (!(e.keyCode in key_states)) {
                 return;
             }
+            e.preventDefault();
             key_states[e.keyCode].down = true;
         });
         document.addEventListener("keyup", function (e) {


### PR DESCRIPTION
… controls are open.

Basically, if you have a small screen like I do, and you open up the controls, the browser default scrolling behavior will take over and pushing the up or down keys will simultaneously move the block/adjust the block and send you upward or downward respectively.

You can recreate this behavior by setting your zoom size to 200%, open the controls and then try playing the game.